### PR TITLE
Allow using yapper-tts w/o using a speaker device

### DIFF
--- a/yapper/speaker.py
+++ b/yapper/speaker.py
@@ -44,10 +44,16 @@ class BaseSpeaker(ABC):
     ----------
     say(text: str)
         Speaks the given text.
+    text_to_wave(text: str, file: str)
+        Speaks the given text, saves the speech to a wave file.
     """
 
     @abstractmethod
     def say(self, text: str):
+        pass
+
+    @abstractmethod
+    def text_to_wave(self, text: str, file: str):
         pass
 
 
@@ -77,6 +83,18 @@ class PyTTSXSpeaker(BaseSpeaker):
         self.voice = voice
         self.rate = rate
         self.volume = volume
+
+    def text_to_wave(self, text: str, file: str):
+        """Saves the speech for the given text into the given file."""
+        engine = tts.init()
+        engine.setProperty("rate", self.rate)
+        engine.setProperty("volume", self.volume)
+        voice_id = engine.getProperty("voices")[
+            int(self.voice == c.VOICE_FEMALE)
+        ].id
+        engine.setProperty("voice", voice_id)
+        engine.save_to_file(text, file)
+        engine.runAndWait()
 
     def say(self, text: str):
         """Speaks the given text"""

--- a/yapper/speaker.py
+++ b/yapper/speaker.py
@@ -29,6 +29,7 @@ def play_wave(wave_f: str):
     wave_f : str
         The wave file to play.
     """
+    pygame.mixer.init() # initialize pygame, safe to call multiple times
     sound = pygame.mixer.Sound(wave_f)
     sound.play()
     while pygame.mixer.get_busy():
@@ -158,7 +159,6 @@ class PiperSpeaker(BaseSpeaker):
             voice, quality, show_progress
         )
         self.onnx_f, self.conf_f = str(self.onnx_f), str(self.conf_f)
-        pygame.mixer.init()
 
     def text_to_wave(self, text: str, file: str):
         """Saves the speech for the given text into the given file."""


### PR DESCRIPTION
I wanted to render voices to wav files, but couldn't use yapper-tts because it would initialize pygame in the constructor of the voice, but inside docker containers that's not usually possible, so I patched it so the init call to pygame is deferred until we have to use it in play_wave, allowing using the library to render voices to wave files w/o using pygame or initializing a speaker device.