### PR TITLE
add speed attribute to PiperSpeaker

### DIFF
--- a/test.py
+++ b/test.py
@@ -146,6 +146,13 @@ def test_speakers():
             except Exception as e:
                 print("error: %r" % (e,))
                 return False
+
+            print("%s -> %s @ 2x" % (locality, voice.value))
+            try:
+                PiperSpeaker(voice=voice, speed=2).say(text)
+            except Exception as e:
+                print("error: %r" % (e,))
+                return False
             finally:
                 print("--------")
     return True

--- a/yapper/speaker.py
+++ b/yapper/speaker.py
@@ -117,6 +117,7 @@ class PiperSpeaker(BaseSpeaker):
         quality: Optional[PiperQuality] = None,
         show_progress: bool = True,
         volume: float = 1.0,
+        speed: float = 1.0,
     ):
         """
         Parameters
@@ -134,6 +135,9 @@ class PiperSpeaker(BaseSpeaker):
         volume : float, optional
             volume to play the wav file at, between 0.0 and 1.0
             (defaults to 1.0)
+        speed : float, optional
+            speed to play the wav file at (ex: 2 for 2x)
+            (defaults to 1.0 for 1x)
         """
         assert isinstance(
             voice, tuple(c.piper_enum_to_lang_code.keys())
@@ -149,6 +153,9 @@ class PiperSpeaker(BaseSpeaker):
 
         self.volume = volume
 
+        self.speed = speed
+        self.length_scale = str(1/self.speed)
+
     def text_to_wave(self, text: str, file: str):
         """Saves the speech for the given text into the given file."""
         subprocess.run(
@@ -161,6 +168,8 @@ class PiperSpeaker(BaseSpeaker):
                 "-f",
                 file,
                 "-q",
+                "--length-scale",
+                self.length_scale  # this "length_scale" is just the speed value inverted
             ],
             input=text.encode("utf-8"),
             stdout=subprocess.DEVNULL,


### PR DESCRIPTION
Adds the ability to increase or decrease the speed of PiperSpeaker, along with the necessary documentation.
This commit also adds testing for 2x speed.